### PR TITLE
Integração do parser com a árvore sintática

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lex.yy.c
 parser.tab.c
 parser.tab.h
 .build/
+compilador

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,38 @@
 CC      ?= gcc
 FLEX    ?= flex
+BISON   ?= bison
 LDLIBS  ?= -lfl
+CFLAGS  ?= -Wall -Wextra -g
 
 SCANNER ?= src/lexer/scanner.l
+PARSER  ?= src/parser/parser.y
+
+AST_H   := src/ast/ast.h
+AST_C   := src/ast/ast.c
+
+# Se existir symtab.c, ele será compilado junto.
+# Se não existir, o Makefile continua funcionando.
+SYMTAB_C := $(wildcard src/symbols/symtab.c)
+
 BUILD   ?= build
-GEN_C   := $(BUILD)/lex.yy.c
-TARGET  := $(BUILD)/lexer.exe
+
+PARSER_C := $(BUILD)/parser.tab.c
+PARSER_H := $(BUILD)/parser.tab.h
+LEX_C    := $(BUILD)/lex.yy.c
+
+COMPILER := $(BUILD)/compilador
+TARGET   := $(COMPILER)
+
+INCLUDES := -I$(BUILD) -Isrc/ast -Isrc/symbols
 
 SCANNER_TEST_BUILD    := $(BUILD)/scanner-tests
 SCANNER_TEST_GEN_C    := $(SCANNER_TEST_BUILD)/lex.yy.c
+SCANNER_TEST_STUB     := $(SCANNER_TEST_BUILD)/scanner_main.c
 SCANNER_TEST_TARGET   := $(SCANNER_TEST_BUILD)/scanner_tests
 SCANNER_TEST_INPUTS   := tests/scanner/inputs
 SCANNER_TEST_EXPECTED := tests/scanner/expected
 SCANNER_TEST_ACTUAL   := $(SCANNER_TEST_BUILD)/actual
+
 VERBOSE ?= 0
 
 TEST_01 := 01_keywords.c
@@ -26,9 +46,9 @@ TEST_08 := 08_simple_program.c
 TEST_09 := 09_function_and_condition.c
 TEST_10 := 10_pointers_arrays.c
 
-.PHONY: all run clean check check-scanner scanner-test test scanner_test test-scanner scanner-test-one help
+.PHONY: all run clean help test scanner-test scanner_test test-scanner scanner-unit-test check-parser check-scanner check-ast
 
-all: $(TARGET)
+all: $(COMPILER)
 
 test: scanner-test
 
@@ -37,41 +57,78 @@ scanner_test: scanner-test
 test-scanner: scanner-test
 
 help:
-	@echo "Targets available:";
-	@echo "  make all            - build the lexer in build/";
-	@echo "  make run            - run the main lexer binary";
-	@echo "  make scanner-test   - run the scanner test suite";
-	@echo "  make scanner-test VERBOSE=1 - print expected/actual .out content";
-	@echo "  make scanner-unit-test TEST=n - run the test mapped by TEST_n";
-	@echo "  make scanner-unit-test TEST=name - run one test by base name";
-	@echo "  make scanner-unit-test INPUT=tests/scanner/inputs/name - run one test by path";
-	@echo "  make test           - alias for scanner-test";
-	@echo "  make clean          - remove build artifacts";
+	@echo "Targets available:"
+	@echo "  make all                         - build the compiler in build/"
+	@echo "  make run                         - run the compiler"
+	@echo "  make scanner-test                - run scanner tests with DEBUG_LEXER=1"
+	@echo "  make scanner-test VERBOSE=1      - print expected/actual .out content"
+	@echo "  make scanner-unit-test TEST=n    - run one scanner test by number"
+	@echo "  make scanner-unit-test TEST=name - run one scanner test by base name"
+	@echo "  make clean                       - remove build artifacts"
+
+check-parser:
+	@if [ ! -f "$(PARSER)" ]; then \
+		echo "Erro: arquivo $(PARSER) nao encontrado."; \
+		exit 1; \
+	fi
 
 check-scanner:
 	@if [ ! -f "$(SCANNER)" ]; then \
 		echo "Erro: arquivo $(SCANNER) nao encontrado."; \
-		echo "Ajuste a variavel SCANNER no Makefile para apontar para o scanner correto."; \
+		exit 1; \
+	fi
+
+check-ast:
+	@if [ ! -f "$(AST_H)" ]; then \
+		echo "Erro: arquivo $(AST_H) nao encontrado."; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(AST_C)" ]; then \
+		echo "Erro: arquivo $(AST_C) nao encontrado."; \
 		exit 1; \
 	fi
 
 $(BUILD):
 	mkdir -p $(BUILD)
 
-$(GEN_C): $(SCANNER) | check $(BUILD)
-	$(FLEX) -o $@ $<
-
-$(TARGET): $(GEN_C)
-	$(CC) $< -o $@ $(LDLIBS)
-
 $(SCANNER_TEST_BUILD):
 	mkdir -p $(SCANNER_TEST_BUILD)
 
-$(SCANNER_TEST_GEN_C): $(SCANNER) | check-scanner $(SCANNER_TEST_BUILD)
-	$(FLEX) -o $@ $<
+$(PARSER_C) $(PARSER_H): $(PARSER) $(AST_H) | check-parser check-ast $(BUILD)
+	$(BISON) -d -o $(PARSER_C) $(PARSER)
 
-$(SCANNER_TEST_TARGET): $(SCANNER_TEST_GEN_C)
-	$(CC) $< -o $@ $(LDLIBS)
+$(LEX_C): $(SCANNER) $(PARSER_H) | check-scanner $(BUILD)
+	$(FLEX) -o $(LEX_C) $(SCANNER)
+
+$(COMPILER): $(PARSER_C) $(LEX_C) $(AST_C) $(SYMTAB_C)
+	$(CC) $(CFLAGS) $(INCLUDES) $(PARSER_C) $(LEX_C) $(AST_C) $(SYMTAB_C) -o $(COMPILER) $(LDLIBS)
+
+run: $(COMPILER)
+	./$(COMPILER)
+
+# --------------------------------------------------------------------
+# Testes do scanner
+#
+# Como o scanner agora usa parser.tab.h e yylval.str, ele precisa de:
+# 1. parser.tab.h gerado pelo Bison
+# 2. um pequeno main de teste
+# 3. DEBUG_LEXER=1 para voltar a imprimir tokens
+# --------------------------------------------------------------------
+
+$(SCANNER_TEST_GEN_C): $(SCANNER) $(PARSER_H) | check-scanner $(SCANNER_TEST_BUILD)
+	$(FLEX) -o $(SCANNER_TEST_GEN_C) $(SCANNER)
+
+$(SCANNER_TEST_STUB): | $(SCANNER_TEST_BUILD)
+	@printf '#include "parser.tab.h"\n' > $(SCANNER_TEST_STUB)
+	@printf 'int yylex(void);\n' >> $(SCANNER_TEST_STUB)
+	@printf 'YYSTYPE yylval;\n' >> $(SCANNER_TEST_STUB)
+	@printf 'int main(void) {\n' >> $(SCANNER_TEST_STUB)
+	@printf '    while (yylex() != 0) {}\n' >> $(SCANNER_TEST_STUB)
+	@printf '    return 0;\n' >> $(SCANNER_TEST_STUB)
+	@printf '}\n' >> $(SCANNER_TEST_STUB)
+
+$(SCANNER_TEST_TARGET): $(SCANNER_TEST_GEN_C) $(SCANNER_TEST_STUB)
+	$(CC) $(CFLAGS) -DDEBUG_LEXER=1 $(INCLUDES) $(SCANNER_TEST_GEN_C) $(SCANNER_TEST_STUB) -o $(SCANNER_TEST_TARGET) $(LDLIBS)
 
 scanner-test: $(SCANNER_TEST_TARGET)
 	@mkdir -p $(SCANNER_TEST_ACTUAL)
@@ -133,8 +190,6 @@ scanner-unit-test: $(SCANNER_TEST_TARGET)
 				*.c) ;; \
 				*) if [ -f "$$input.c" ]; then \
 					input="$$input.c"; \
-				elif [ -f "$$input.c" ]; then \
-					input="$$input.c"; \
 				else \
 					input="$$input.c"; \
 				fi ;; \
@@ -172,9 +227,6 @@ scanner-unit-test: $(SCANNER_TEST_TARGET)
 		diff -u --strip-trailing-cr "$$expected" "$$actual" || true; \
 		exit 1; \
 	fi
-
-run: $(TARGET)
-	./$(TARGET)
 
 clean:
 	rm -rf $(BUILD)

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -1,33 +1,117 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "ast.h"
 
-// Cria um nó na árvore, recebendo o tipo, p filho da esquerda, o filho da direta e o valor (se for um número ou variável)
-NoAST* criar_no(TipoNo tipo, NoAST *esq, NoAST *dir, char *valor) { 
-    
-    NoAST *novo = (NoAST*) malloc(sizeof(NoAST)); // memoria para o novo nó
-    if (!novo) return NULL; // verifica a alocação da memoria
+/*
+ * Copia uma string para memória nova.
+ *
+ * Isso é importante porque valores vindos do lexer/parser podem mudar
+ * ou deixar de existir depois da leitura de novos tokens.
+ */
+static char *copiar_string(const char *texto) {
+    if (texto == NULL) {
+        return NULL;
+    }
 
-    // Preenche os campos
+    char *copia = malloc(strlen(texto) + 1);
+
+    if (copia == NULL) {
+        return NULL;
+    }
+
+    strcpy(copia, texto);
+    return copia;
+}
+
+/*
+ * Cria um novo nó da árvore sintática.
+ */
+NoAST* criar_no(TipoNo tipo, NoAST *esq, NoAST *dir, const char *valor) {
+    NoAST *novo = malloc(sizeof(NoAST));
+
+    if (novo == NULL) {
+        return NULL;
+    }
+
     novo->tipo = tipo;
     novo->esq = esq;
     novo->dir = dir;
-    novo->valor = valor;
+    novo->valor = copiar_string(valor);
 
     return novo;
 }
 
-// Função pra mostrar a arvore, vamos usar pra debugar
+
+static const char *nome_tipo_no(TipoNo tipo) {
+    switch (tipo) {
+        case NO_PROGRAMA: return "NO_PROGRAMA";
+        case NO_LISTA: return "NO_LISTA";
+        case NO_FUNCAO: return "NO_FUNCAO";
+        case NO_PARAMETRO: return "NO_PARAMETRO";
+        case NO_TIPO: return "NO_TIPO";
+        case NO_BLOCO: return "NO_BLOCO";
+
+        case NO_DECLARACAO: return "NO_DECLARACAO";
+        case NO_ATRIBUICAO: return "NO_ATRIBUICAO";
+        case NO_RETORNO: return "NO_RETORNO";
+
+        case NO_IF: return "NO_IF";
+        case NO_WHILE: return "NO_WHILE";
+        case NO_FOR: return "NO_FOR";
+
+        case NO_BINARIO: return "NO_BINARIO";
+        case NO_UNARIO: return "NO_UNARIO";
+
+        case NO_IDENTIFICADOR: return "NO_IDENTIFICADOR";
+        case NO_NUMERO: return "NO_NUMERO";
+        case NO_ACESSO_VETOR: return "NO_ACESSO_VETOR";
+
+        case NO_VAZIO: return "NO_VAZIO";
+
+        default: return "NO_DESCONHECIDO";
+    }
+}
+
+/*
+ * Imprime a AST com indentação.
+ *
+ * Cada nível da árvore recebe dois espaços de recuo.
+ */
 void imprimir_ast(NoAST *raiz, int nivel) {
-    if (raiz == NULL) return;
+    if (raiz == NULL) {
+        return;
+    }
 
-    // Faz um recuo baseado no nível da árvore para ficar visualmente bonito
-    for (int i = 0; i < nivel; i++) printf("  ");
+    for (int i = 0; i < nivel; i++) {
+        printf("  ");
+    }
 
-    // Imprime o tipo do nó
-    printf("Nó: %d (Valor: %s)\n", raiz->tipo, raiz->valor ? raiz->valor : "NULL");
+    printf("%s", nome_tipo_no(raiz->tipo));
 
-    // Chama recursivamente para os filhos
+    if (raiz->valor != NULL) {
+        printf(" (%s)", raiz->valor);
+    }
+
+    printf("\n");
+
     imprimir_ast(raiz->esq, nivel + 1);
     imprimir_ast(raiz->dir, nivel + 1);
+}
+
+/*
+ * Libera recursivamente a memória da árvore.
+ *
+ * Primeiro libera os filhos, depois o próprio nó.
+ */
+void liberar_ast(NoAST *raiz) {
+    if (raiz == NULL) {
+        return;
+    }
+
+    liberar_ast(raiz->esq);
+    liberar_ast(raiz->dir);
+
+    free(raiz->valor);
+    free(raiz);
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,21 +1,68 @@
 #ifndef AST_H
 #define AST_H
 
+/*
+ * Enum que representa os tipos de nós possíveis na árvore sintática.
+ * Cada constante representa uma construção da linguagem:
+ * programa, função, declaração, expressão, etc.
+ */
 typedef enum {
-// Tipos de nós temos que ir adicionando conforme a gente for implementando o parser
+    NO_PROGRAMA,
+    NO_LISTA,
+    NO_FUNCAO,
+    NO_PARAMETRO,
+    NO_TIPO,
+    NO_BLOCO,
+
+    NO_DECLARACAO,
+    NO_ATRIBUICAO,
+    NO_RETORNO,
+
+    NO_IF,
+    NO_WHILE,
+    NO_FOR,
+
+    NO_BINARIO,
+    NO_UNARIO,
+
+    NO_IDENTIFICADOR,
+    NO_NUMERO,
+    NO_ACESSO_VETOR,
+
+    NO_VAZIO
 } TipoNo;
 
+/*
+ * Estrutura básica de um nó da AST.
+ *
+ * tipo  -> indica qual construção esse nó representa.
+ * valor -> guarda textos importantes, como nome de variável, número ou operador.
+ * esq   -> filho esquerdo.
+ * dir   -> filho direito.
+ *
+ * A árvore foi modelada como binária para simplificar a integração inicial.
+ */
 typedef struct NoAST {
-    TipoNo tipo;          // Fala o tipo do nó (variável, operação, etc.) ex: NO_SOMA
-    char *valor;          // O texto, se for um número ou variável
-    struct NoAST *esq;    // Filho da esquerda
-    struct NoAST *dir;    // Filho da direita
+    TipoNo tipo;
+    char *valor;
+    struct NoAST *esq;
+    struct NoAST *dir;
 } NoAST;
 
-// Função de criação
-NoAST* criar_no(TipoNo tipo, NoAST *esq, NoAST *dir, char *valor);
+/*
+ * Cria dinamicamente um novo nó da AST.
+ */
+NoAST* criar_no(TipoNo tipo, NoAST *esq, NoAST *dir, const char *valor);
 
-// Função para debugar (ver se a árvore foi montada certa)
+/*
+ * Imprime a árvore de forma recursiva.
+ * Usada principalmente para debug.
+ */
 void imprimir_ast(NoAST *raiz, int nivel);
+
+/*
+ * Libera toda a memória alocada pela AST.
+ */
+void liberar_ast(NoAST *raiz);
 
 #endif

--- a/src/lexer/scanner.l
+++ b/src/lexer/scanner.l
@@ -1,104 +1,157 @@
 %{
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "parser.tab.h"
+
+/*
+ * Controla se o lexer deve imprimir os tokens reconhecidos.
+ *
+ * Para testar só o scanner, você pode trocar para 1.
+ * Para integrar com o parser/AST, mantenha 0 para a saída não ficar poluída.
+ */
+#ifndef DEBUG_LEXER
+#define DEBUG_LEXER 0
+#endif
+
+#define LEX_PRINT(...)              \
+    do {                            \
+        if (DEBUG_LEXER) {          \
+            printf(__VA_ARGS__);    \
+        }                           \
+    } while (0)
+
+/*
+ * Copia o texto atual reconhecido pelo lexer.
+ *
+ * yytext é reutilizado pelo Flex a cada novo token.
+ * Por isso, quando precisamos guardar o texto no parser,
+ * fazemos uma cópia dinâmica da string.
+ */
+static char *copiar_yytext(const char *texto) {
+    char *copia = malloc(strlen(texto) + 1);
+
+    if (copia == NULL) {
+        return NULL;
+    }
+
+    strcpy(copia, texto);
+    return copia;
+}
 %}
-/* Definições de padrões de token e ações */
+
+/*
+ * Evita warnings de funções geradas pelo Flex que não usamos.
+ */
+%option noinput nounput
+
 %%
 
-auto        { printf("KW_AUTO\n"); return KW_AUTO; }
-break       { printf("KW_BREAK\n"); return KW_BREAK; }
-case        { printf("KW_CASE\n"); return KW_CASE; }
-char        { printf("KW_CHAR\n"); return KW_CHAR; }
-const       { printf("KW_CONST\n"); return KW_CONST; }
-continue    { printf("KW_CONTINUE\n"); return KW_CONTINUE; }
-default     { printf("KW_DEFAULT\n"); return KW_DEFAULT; }
-do          { printf("KW_DO\n"); return KW_DO; }
-double      { printf("KW_DOUBLE\n"); return KW_DOUBLE; }
-else        { printf("KW_ELSE\n"); return KW_ELSE; }
-enum        { printf("KW_ENUM\n"); return KW_ENUM; }
-extern      { printf("KW_EXTERN\n"); return KW_EXTERN; }
-float       { printf("KW_FLOAT\n"); return KW_FLOAT; }
-for         { printf("KW_FOR\n"); return KW_FOR; }
-goto        { printf("KW_GOTO\n"); return KW_GOTO; }
-if          { printf("KW_IF\n"); return KW_IF; }
-int         { printf("KW_INT\n"); return KW_INT; }
-long        { printf("KW_LONG\n"); return KW_LONG; }
-register    { printf("KW_REGISTER\n"); return KW_REGISTER; }
-return      { printf("KW_RETURN\n"); return KW_RETURN; }
-short       { printf("KW_SHORT\n"); return KW_SHORT; }
-signed      { printf("KW_SIGNED\n"); return KW_SIGNED; }
-sizeof      { printf("KW_SIZEOF\n"); return KW_SIZEOF; }
-static      { printf("KW_STATIC\n"); return KW_STATIC; }
-struct      { printf("KW_STRUCT\n"); return KW_STRUCT; }
-switch      { printf("KW_SWITCH\n"); return KW_SWITCH; }
-typedef     { printf("KW_TYPEDEF\n"); return KW_TYPEDEF; }
-union       { printf("KW_UNION\n"); return KW_UNION; }
-unsigned    { printf("KW_UNSIGNED\n"); return KW_UNSIGNED; }
-void        { printf("KW_VOID\n"); return KW_VOID; }
-volatile    { printf("KW_VOLATILE\n"); return KW_VOLATILE; }
-while       { printf("KW_WHILE\n"); return KW_WHILE; }
+auto        { LEX_PRINT("KW_AUTO\n"); return KW_AUTO; }
+break       { LEX_PRINT("KW_BREAK\n"); return KW_BREAK; }
+case        { LEX_PRINT("KW_CASE\n"); return KW_CASE; }
+char        { LEX_PRINT("KW_CHAR\n"); return KW_CHAR; }
+const       { LEX_PRINT("KW_CONST\n"); return KW_CONST; }
+continue    { LEX_PRINT("KW_CONTINUE\n"); return KW_CONTINUE; }
+default     { LEX_PRINT("KW_DEFAULT\n"); return KW_DEFAULT; }
+do          { LEX_PRINT("KW_DO\n"); return KW_DO; }
+double      { LEX_PRINT("KW_DOUBLE\n"); return KW_DOUBLE; }
+else        { LEX_PRINT("KW_ELSE\n"); return KW_ELSE; }
+enum        { LEX_PRINT("KW_ENUM\n"); return KW_ENUM; }
+extern      { LEX_PRINT("KW_EXTERN\n"); return KW_EXTERN; }
+float       { LEX_PRINT("KW_FLOAT\n"); return KW_FLOAT; }
+for         { LEX_PRINT("KW_FOR\n"); return KW_FOR; }
+goto        { LEX_PRINT("KW_GOTO\n"); return KW_GOTO; }
+if          { LEX_PRINT("KW_IF\n"); return KW_IF; }
+int         { LEX_PRINT("KW_INT\n"); return KW_INT; }
+long        { LEX_PRINT("KW_LONG\n"); return KW_LONG; }
+register    { LEX_PRINT("KW_REGISTER\n"); return KW_REGISTER; }
+return      { LEX_PRINT("KW_RETURN\n"); return KW_RETURN; }
+short       { LEX_PRINT("KW_SHORT\n"); return KW_SHORT; }
+signed      { LEX_PRINT("KW_SIGNED\n"); return KW_SIGNED; }
+sizeof      { LEX_PRINT("KW_SIZEOF\n"); return KW_SIZEOF; }
+static      { LEX_PRINT("KW_STATIC\n"); return KW_STATIC; }
+struct      { LEX_PRINT("KW_STRUCT\n"); return KW_STRUCT; }
+switch      { LEX_PRINT("KW_SWITCH\n"); return KW_SWITCH; }
+typedef     { LEX_PRINT("KW_TYPEDEF\n"); return KW_TYPEDEF; }
+union       { LEX_PRINT("KW_UNION\n"); return KW_UNION; }
+unsigned    { LEX_PRINT("KW_UNSIGNED\n"); return KW_UNSIGNED; }
+void        { LEX_PRINT("KW_VOID\n"); return KW_VOID; }
+volatile    { LEX_PRINT("KW_VOLATILE\n"); return KW_VOLATILE; }
+while       { LEX_PRINT("KW_WHILE\n"); return KW_WHILE; }
 
-"//".*      { /* ignora comentário de linha */ }
+"//".*      { /* Ignora comentário de linha. */ }
 
-"/*"([^*]|\*+[^*/])*\*+\/    { /* ignora comentário de bloco */ }
+"/*"([^*]|\*+[^*/])*\*+\/    { /* Ignora comentário de bloco. */ }
 
 [a-zA-Z_][a-zA-Z0-9_]* {
-    printf("IDENT(%s)\n", yytext);
+    /*
+     * Envia o nome do identificador para o parser.
+     * Exemplo: x, idade, contador.
+     */
+    yylval.str = copiar_yytext(yytext);
+    LEX_PRINT("IDENT(%s)\n", yytext);
     return IDENT;
 }
 
 [0-9]+(\.[0-9]+)? {
-    printf("NUMBER(%s)\n", yytext);
+    /*
+     * Envia o número como texto para o parser.
+     * A análise semântica pode decidir depois se é int ou float.
+     */
+    yylval.str = copiar_yytext(yytext);
+    LEX_PRINT("NUMBER(%s)\n", yytext);
     return NUMBER;
 }
-   /* --- Operadores de 2 Caracteres --- */
 
-"=="        { printf("TK_OP_IGUAL_COMPARACAO\n"); return TK_OP_IGUAL_COMPARACAO; }
-"!="        { printf("TK_OP_DIFERENTE\n"); return TK_OP_DIFERENTE; }
-"<="        { printf("TK_OP_MENOR_IGUAL\n"); return TK_OP_MENOR_IGUAL; }
-">="        { printf("TK_OP_MAIOR_IGUAL\n"); return TK_OP_MAIOR_IGUAL; }
-"&&"        { printf("TK_OP_AND\n"); return TK_OP_AND; }
-"||"        { printf("TK_OP_OR\n"); return TK_OP_OR; }
-"++"        { printf("TK_OP_INCREMENTO\n"); return TK_OP_INCREMENTO; }
-"--"        { printf("TK_OP_DECREMENTO\n"); return TK_OP_DECREMENTO; }
-"+="        { printf("TK_OP_MAIS_IGUAL\n"); return TK_OP_MAIS_IGUAL; }
-"-="        { printf("TK_OP_MENOS_IGUAL\n"); return TK_OP_MENOS_IGUAL; }
-"*="        { printf("TK_OP_MULTIPLICACAO_IGUAL\n"); return TK_OP_MULTIPLICACAO_IGUAL; }
-"/="        { printf("TK_OP_DIVISAO_IGUAL\n"); return TK_OP_DIVISAO_IGUAL; }
-"%="        { printf("TK_OP_MODULO_IGUAL\n"); return TK_OP_MODULO_IGUAL; }
-"<<"        { printf("TK_OP_DESLOCAMENTO_ESQUERDA\n"); return TK_OP_DESLOCAMENTO_ESQUERDA; }
-">>"        { printf("TK_OP_DESLOCAMENTO_DIREITA\n"); return TK_OP_DESLOCAMENTO_DIREITA; }
-"->"        { printf("TK_OP_PONTEIRO_ACESSO\n"); return TK_OP_PONTEIRO_ACESSO; }
+    /* Operadores de 2 caracteres. */
 
-    /* --- Operadores de 1 Caractere --- */
+"=="        { LEX_PRINT("TK_OP_IGUAL_COMPARACAO\n"); return TK_OP_IGUAL_COMPARACAO; }
+"!="        { LEX_PRINT("TK_OP_DIFERENTE\n"); return TK_OP_DIFERENTE; }
+"<="        { LEX_PRINT("TK_OP_MENOR_IGUAL\n"); return TK_OP_MENOR_IGUAL; }
+">="        { LEX_PRINT("TK_OP_MAIOR_IGUAL\n"); return TK_OP_MAIOR_IGUAL; }
+"&&"        { LEX_PRINT("TK_OP_AND\n"); return TK_OP_AND; }
+"||"        { LEX_PRINT("TK_OP_OR\n"); return TK_OP_OR; }
+"++"        { LEX_PRINT("TK_OP_INCREMENTO\n"); return TK_OP_INCREMENTO; }
+"--"        { LEX_PRINT("TK_OP_DECREMENTO\n"); return TK_OP_DECREMENTO; }
+"+="        { LEX_PRINT("TK_OP_MAIS_IGUAL\n"); return TK_OP_MAIS_IGUAL; }
+"-="        { LEX_PRINT("TK_OP_MENOS_IGUAL\n"); return TK_OP_MENOS_IGUAL; }
+"*="        { LEX_PRINT("TK_OP_MULTIPLICACAO_IGUAL\n"); return TK_OP_MULTIPLICACAO_IGUAL; }
+"/="        { LEX_PRINT("TK_OP_DIVISAO_IGUAL\n"); return TK_OP_DIVISAO_IGUAL; }
+"%="        { LEX_PRINT("TK_OP_MODULO_IGUAL\n"); return TK_OP_MODULO_IGUAL; }
+"<<"        { LEX_PRINT("TK_OP_DESLOCAMENTO_ESQUERDA\n"); return TK_OP_DESLOCAMENTO_ESQUERDA; }
+">>"        { LEX_PRINT("TK_OP_DESLOCAMENTO_DIREITA\n"); return TK_OP_DESLOCAMENTO_DIREITA; }
+"->"        { LEX_PRINT("TK_OP_PONTEIRO_ACESSO\n"); return TK_OP_PONTEIRO_ACESSO; }
 
-"+"         { printf("TK_OP_SOMA\n"); return TK_OP_SOMA; }
-"-"         { printf("TK_OP_SUBTRACAO\n"); return TK_OP_SUBTRACAO; }
-"*"         { printf("TK_OP_MULTIPLICACAO\n"); return TK_OP_MULTIPLICACAO; }
-"/"         { printf("TK_OP_DIVISAO\n"); return TK_OP_DIVISAO; }
-"%"         { printf("TK_OP_MODULO\n"); return TK_OP_MODULO; }
-"="         { printf("TK_OP_IGUAL\n"); return TK_OP_IGUAL; }
-"<"         { printf("TK_OP_MENOR\n"); return TK_OP_MENOR; }
-">"         { printf("TK_OP_MAIOR\n"); return TK_OP_MAIOR; }
-"!"         { printf("TK_OP_NAO\n"); return TK_OP_NAO; }
-"&"         { printf("TK_OP_E_BIT\n"); return TK_OP_E_BIT; }
-"|"         { printf("TK_OP_OU_BIT\n"); return TK_OP_OU_BIT; }
-"^"         { printf("TK_OP_XOR_BIT\n"); return TK_OP_XOR_BIT; }
-"~"         { printf("TK_OP_NOT_BIT\n"); return TK_OP_NOT_BIT; }
-"?"         { printf("TK_OP_TERNARIO\n"); return TK_OP_TERNARIO; }
-":"         { printf("TK_OP_DOIS_PONTOS\n"); return TK_OP_DOIS_PONTOS; }
-"."         { printf("TK_OP_PONTO\n"); return TK_OP_PONTO; }
-","         { printf("TK_OP_VIRGULA\n"); return TK_OP_VIRGULA; }
-";"         { printf("TK_OP_PONTO_VIRGULA\n"); return TK_OP_PONTO_VIRGULA; }
+    /* Operadores de 1 caractere. */
 
-"("         { printf("TK_ABRE_PARENTESE\n"); return TK_ABRE_PARENTESE; }
-")"         { printf("TK_FECHA_PARENTESE\n"); return TK_FECHA_PARENTESE; }
-"{"         { printf("TK_ABRE_CHAVE\n"); return TK_ABRE_CHAVE; }
-"}"         { printf("TK_FECHA_CHAVE\n"); return TK_FECHA_CHAVE; }
-"["         { printf("TK_ABRE_COLCHETE\n"); return TK_ABRE_COLCHETE; }
-"]"         { printf("TK_FECHA_COLCHETE\n"); return TK_FECHA_COLCHETE; }
+"+"         { LEX_PRINT("TK_OP_SOMA\n"); return TK_OP_SOMA; }
+"-"         { LEX_PRINT("TK_OP_SUBTRACAO\n"); return TK_OP_SUBTRACAO; }
+"*"         { LEX_PRINT("TK_OP_MULTIPLICACAO\n"); return TK_OP_MULTIPLICACAO; }
+"/"         { LEX_PRINT("TK_OP_DIVISAO\n"); return TK_OP_DIVISAO; }
+"%"         { LEX_PRINT("TK_OP_MODULO\n"); return TK_OP_MODULO; }
+"="         { LEX_PRINT("TK_OP_IGUAL\n"); return TK_OP_IGUAL; }
+"<"         { LEX_PRINT("TK_OP_MENOR\n"); return TK_OP_MENOR; }
+">"         { LEX_PRINT("TK_OP_MAIOR\n"); return TK_OP_MAIOR; }
+"!"         { LEX_PRINT("TK_OP_NAO\n"); return TK_OP_NAO; }
+"&"         { LEX_PRINT("TK_OP_E_BIT\n"); return TK_OP_E_BIT; }
+"|"         { LEX_PRINT("TK_OP_OU_BIT\n"); return TK_OP_OU_BIT; }
+"^"         { LEX_PRINT("TK_OP_XOR_BIT\n"); return TK_OP_XOR_BIT; }
+"~"         { LEX_PRINT("TK_OP_NOT_BIT\n"); return TK_OP_NOT_BIT; }
+"?"         { LEX_PRINT("TK_OP_TERNARIO\n"); return TK_OP_TERNARIO; }
+":"         { LEX_PRINT("TK_OP_DOIS_PONTOS\n"); return TK_OP_DOIS_PONTOS; }
+"."         { LEX_PRINT("TK_OP_PONTO\n"); return TK_OP_PONTO; }
+","         { LEX_PRINT("TK_OP_VIRGULA\n"); return TK_OP_VIRGULA; }
+";"         { LEX_PRINT("TK_OP_PONTO_VIRGULA\n"); return TK_OP_PONTO_VIRGULA; }
 
-[ \t\n\r]+ { /* ignora espaços, quebras de linha e CRLF */ }
+"("         { LEX_PRINT("TK_ABRE_PARENTESE\n"); return TK_ABRE_PARENTESE; }
+")"         { LEX_PRINT("TK_FECHA_PARENTESE\n"); return TK_FECHA_PARENTESE; }
+"{"         { LEX_PRINT("TK_ABRE_CHAVE\n"); return TK_ABRE_CHAVE; }
+"}"         { LEX_PRINT("TK_FECHA_CHAVE\n"); return TK_FECHA_CHAVE; }
+"["         { LEX_PRINT("TK_ABRE_COLCHETE\n"); return TK_ABRE_COLCHETE; }
+"]"         { LEX_PRINT("TK_FECHA_COLCHETE\n"); return TK_FECHA_COLCHETE; }
+
+[ \t\n\r]+ { /* Ignora espaços, tabs e quebras de linha. */ }
 
 .           { printf("UNKNOWN(%s)\n", yytext); }
 

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -1,11 +1,35 @@
+%code requires {
+    #include "ast.h"
+}
+
 %{
 #include <stdio.h>
 #include <stdlib.h>
+#include "ast.h"
 #include "symtab.h"
 
+/*
+ * Função gerada pelo Flex.
+ * O parser chama yylex() sempre que precisa do próximo token.
+ */
 int yylex(void);
+
+/*
+ * Função chamada pelo Bison quando encontra erro sintático.
+ */
 void yyerror(const char *s);
+
+/*
+ * Ponteiro global para guardar a raiz da árvore sintática.
+ * No final do parsing, essa variável apontará para o nó NO_PROGRAMA.
+ */
+NoAST *raiz_ast = NULL;
 %}
+
+%union {
+    char *str;
+    NoAST *no;
+}
 
 /* Palavras reservadas */
 %token KW_AUTO
@@ -42,8 +66,8 @@ void yyerror(const char *s);
 %token KW_WHILE
 
 /* Identificadores e números */
-%token IDENT
-%token NUMBER
+%token <str> IDENT
+%token <str> NUMBER
 
 /* Operadores compostos */
 %token TK_OP_IGUAL_COMPARACAO
@@ -103,173 +127,527 @@ void yyerror(const char *s);
 %nonassoc LOWER_THAN_ELSE
 %nonassoc KW_ELSE
 
+/*
+ * Regras que produzem nós da AST.
+ * Cada regra declarada com <no> usa $$, $1, $2 etc. como NoAST*.
+ */
+%type <no> programa
+%type <no> lista_funcoes funcao
+%type <no> parametros lista_parametros parametro
+%type <no> tipo bloco lista_comandos comando
+%type <no> declaracao atribuicao incremento retorno
+%type <no> comando_if comando_while comando_for
+%type <no> for_init for_condicao for_atualizacao
+%type <no> declaracao_for atribuicao_for incremento_for
+%type <no> expressao_booleana expressao termo fator acesso_vetor
+
+/* operador_relacional devolve o símbolo textual do operador: <, >, <=, >=, == ou != */
+%type <str> operador_relacional
+
 %%
 
 programa:
       lista_funcoes
       {
+        /*
+         * Raiz da AST.
+         * Tudo que foi reconhecido no programa fica abaixo de NO_PROGRAMA.
+         */
+        raiz_ast = criar_no(NO_PROGRAMA, $1, NULL, NULL);
+        $$ = raiz_ast;
+
         printf("Análise sintática concluída\n");
+        imprimir_ast(raiz_ast, 0);
       }
 ;
 
 lista_funcoes:
       lista_funcoes funcao
+      {
+        /* Encadeia múltiplas funções em uma lista binária. */
+        $$ = criar_no(NO_LISTA, $1, $2, NULL);
+      }
     | funcao
+      {
+        $$ = $1;
+      }
 ;
 
 funcao:
       tipo IDENT TK_ABRE_PARENTESE parametros TK_FECHA_PARENTESE bloco
+      {
+        /*
+         * Função:
+         * valor -> nome da função
+         * esq   -> lista contendo tipo e parâmetros
+         * dir   -> bloco da função
+         */
+        NoAST *cabecalho = criar_no(NO_LISTA, $1, $4, NULL);
+        $$ = criar_no(NO_FUNCAO, cabecalho, $6, $2);
+        free($2);
+      }
 ;
 
 parametros:
       lista_parametros
+      {
+        $$ = $1;
+      }
     | /* vazio */
+      {
+        $$ = NULL;
+      }
 ;
 
 lista_parametros:
       lista_parametros TK_OP_VIRGULA parametro
+      {
+        $$ = criar_no(NO_LISTA, $1, $3, NULL);
+      }
     | parametro
+      {
+        $$ = $1;
+      }
 ;
 
 parametro:
       tipo IDENT
+      {
+        /*
+         * Parâmetro de função.
+         * Exemplo: int x
+         */
+        $$ = criar_no(NO_PARAMETRO, $1, NULL, $2);
+        free($2);
+      }
 ;
 
 tipo:
       KW_INT
+      {
+        $$ = criar_no(NO_TIPO, NULL, NULL, "int");
+      }
     | KW_FLOAT
+      {
+        $$ = criar_no(NO_TIPO, NULL, NULL, "float");
+      }
     | KW_VOID
+      {
+        $$ = criar_no(NO_TIPO, NULL, NULL, "void");
+      }
 ;
 
 bloco:
       TK_ABRE_CHAVE lista_comandos TK_FECHA_CHAVE
+      {
+        $$ = criar_no(NO_BLOCO, $2, NULL, NULL);
+      }
 ;
 
 lista_comandos:
       lista_comandos comando
+      {
+        $$ = criar_no(NO_LISTA, $1, $2, NULL);
+      }
     | /* vazio */
+      {
+        $$ = NULL;
+      }
 ;
 
 comando:
       declaracao
+      {
+        $$ = $1;
+      }
     | atribuicao
+      {
+        $$ = $1;
+      }
     | retorno
+      {
+        $$ = $1;
+      }
     | comando_if
+      {
+        $$ = $1;
+      }
     | comando_while
+      {
+        $$ = $1;
+      }
     | comando_for
+      {
+        $$ = $1;
+      }
     | incremento
+      {
+        $$ = $1;
+      }
     | bloco
+      {
+        $$ = $1;
+      }
 ;
 
 declaracao:
       tipo IDENT TK_OP_PONTO_VIRGULA
+      {
+        /*
+         * Declaração simples.
+         * Exemplo: int x;
+         */
+        $$ = criar_no(NO_DECLARACAO, $1, NULL, $2);
+        free($2);
+      }
     | tipo IDENT TK_OP_IGUAL expressao TK_OP_PONTO_VIRGULA
+      {
+        /*
+         * Declaração com inicialização.
+         * Exemplo: int x = 10 + 2;
+         */
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        NoAST *atribuicao_inicial = criar_no(NO_ATRIBUICAO, id, $4, "=");
+        $$ = criar_no(NO_DECLARACAO, $1, atribuicao_inicial, $2);
+        free($2);
+      }
     | tipo IDENT TK_ABRE_COLCHETE NUMBER TK_FECHA_COLCHETE TK_OP_PONTO_VIRGULA
+      {
+        /*
+         * Declaração de vetor.
+         * Exemplo: int v[10];
+         */
+        NoAST *tamanho = criar_no(NO_NUMERO, NULL, NULL, $4);
+        $$ = criar_no(NO_DECLARACAO, $1, tamanho, $2);
+        free($2);
+        free($4);
+      }
 ;
 
 atribuicao:
       IDENT TK_OP_IGUAL expressao TK_OP_PONTO_VIRGULA
+      {
+        /*
+         * Atribuição simples.
+         * Exemplo: x = 10 + 2;
+         */
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_ATRIBUICAO, id, $3, "=");
+        free($1);
+      }
 ;
 
 incremento:
       IDENT TK_OP_INCREMENTO TK_OP_PONTO_VIRGULA
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_UNARIO, id, NULL, "++pos");
+        free($1);
+      }
     | IDENT TK_OP_DECREMENTO TK_OP_PONTO_VIRGULA
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_UNARIO, id, NULL, "--pos");
+        free($1);
+      }
     | TK_OP_INCREMENTO IDENT TK_OP_PONTO_VIRGULA
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        $$ = criar_no(NO_UNARIO, id, NULL, "++pre");
+        free($2);
+      }
     | TK_OP_DECREMENTO IDENT TK_OP_PONTO_VIRGULA
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        $$ = criar_no(NO_UNARIO, id, NULL, "--pre");
+        free($2);
+      }
 ;
 
 retorno:
       KW_RETURN expressao TK_OP_PONTO_VIRGULA
+      {
+        $$ = criar_no(NO_RETORNO, $2, NULL, NULL);
+      }
     | KW_RETURN TK_OP_PONTO_VIRGULA
+      {
+        $$ = criar_no(NO_RETORNO, NULL, NULL, NULL);
+      }
 ;
 
 comando_if:
       KW_IF TK_ABRE_PARENTESE expressao_booleana TK_FECHA_PARENTESE bloco %prec LOWER_THAN_ELSE
+      {
+        /*
+         * If sem else.
+         * esq -> condição
+         * dir -> bloco do if
+         */
+        $$ = criar_no(NO_IF, $3, $5, "if");
+      }
     | KW_IF TK_ABRE_PARENTESE expressao_booleana TK_FECHA_PARENTESE bloco KW_ELSE bloco
+      {
+        /*
+         * If com else.
+         * esq -> condição
+         * dir -> lista contendo bloco do if e bloco do else
+         */
+        NoAST *blocos = criar_no(NO_LISTA, $5, $7, NULL);
+        $$ = criar_no(NO_IF, $3, blocos, "if_else");
+      }
 ;
 
 comando_while:
       KW_WHILE TK_ABRE_PARENTESE expressao_booleana TK_FECHA_PARENTESE bloco
+      {
+        /*
+         * While.
+         * esq -> condição
+         * dir -> bloco repetido
+         */
+        $$ = criar_no(NO_WHILE, $3, $5, NULL);
+      }
 ;
 
 comando_for:
       KW_FOR TK_ABRE_PARENTESE for_init TK_OP_PONTO_VIRGULA for_condicao TK_OP_PONTO_VIRGULA for_atualizacao TK_FECHA_PARENTESE bloco
+      {
+        /*
+         * For.
+         * Como a AST é binária, agrupamos init, condição e atualização em listas.
+         */
+        NoAST *cabecalho_parcial = criar_no(NO_LISTA, $3, $5, NULL);
+        NoAST *cabecalho = criar_no(NO_LISTA, cabecalho_parcial, $7, NULL);
+        $$ = criar_no(NO_FOR, cabecalho, $9, NULL);
+      }
 ;
 
 for_init:
       declaracao_for
+      {
+        $$ = $1;
+      }
     | atribuicao_for
+      {
+        $$ = $1;
+      }
     | /* vazio */
+      {
+        $$ = NULL;
+      }
 ;
 
 for_condicao:
       expressao_booleana
+      {
+        $$ = $1;
+      }
     | /* vazio */
+      {
+        $$ = NULL;
+      }
 ;
 
 for_atualizacao:
       atribuicao_for
+      {
+        $$ = $1;
+      }
     | incremento_for
+      {
+        $$ = $1;
+      }
     | /* vazio */
+      {
+        $$ = NULL;
+      }
 ;
 
 declaracao_for:
       tipo IDENT
+      {
+        $$ = criar_no(NO_DECLARACAO, $1, NULL, $2);
+        free($2);
+      }
     | tipo IDENT TK_OP_IGUAL expressao
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        NoAST *atribuicao_inicial = criar_no(NO_ATRIBUICAO, id, $4, "=");
+        $$ = criar_no(NO_DECLARACAO, $1, atribuicao_inicial, $2);
+        free($2);
+      }
 ;
 
 atribuicao_for:
       IDENT TK_OP_IGUAL expressao
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_ATRIBUICAO, id, $3, "=");
+        free($1);
+      }
     | IDENT TK_OP_MAIS_IGUAL expressao
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_ATRIBUICAO, id, $3, "+=");
+        free($1);
+      }
     | IDENT TK_OP_MENOS_IGUAL expressao
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_ATRIBUICAO, id, $3, "-=");
+        free($1);
+      }
 ;
 
 incremento_for:
       IDENT TK_OP_INCREMENTO
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_UNARIO, id, NULL, "++pos");
+        free($1);
+      }
     | IDENT TK_OP_DECREMENTO
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        $$ = criar_no(NO_UNARIO, id, NULL, "--pos");
+        free($1);
+      }
     | TK_OP_INCREMENTO IDENT
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        $$ = criar_no(NO_UNARIO, id, NULL, "++pre");
+        free($2);
+      }
     | TK_OP_DECREMENTO IDENT
+      {
+        NoAST *id = criar_no(NO_IDENTIFICADOR, NULL, NULL, $2);
+        $$ = criar_no(NO_UNARIO, id, NULL, "--pre");
+        free($2);
+      }
 ;
-
 
 expressao_booleana:
       expressao operador_relacional expressao
+      {
+        /*
+         * Expressão relacional.
+         * Exemplo: x < 10
+         */
+        $$ = criar_no(NO_BINARIO, $1, $3, $2);
+      }
     | expressao_booleana TK_OP_AND expressao_booleana
+      {
+        $$ = criar_no(NO_BINARIO, $1, $3, "&&");
+      }
     | expressao_booleana TK_OP_OR expressao_booleana
+      {
+        $$ = criar_no(NO_BINARIO, $1, $3, "||");
+      }
     | TK_ABRE_PARENTESE expressao_booleana TK_FECHA_PARENTESE
+      {
+        $$ = $2;
+      }
 ;
 
 operador_relacional:
       TK_OP_MENOR
+      {
+        $$ = "<";
+      }
     | TK_OP_MAIOR
+      {
+        $$ = ">";
+      }
     | TK_OP_MENOR_IGUAL
+      {
+        $$ = "<=";
+      }
     | TK_OP_MAIOR_IGUAL
+      {
+        $$ = ">=";
+      }
     | TK_OP_IGUAL_COMPARACAO
+      {
+        $$ = "==";
+      }
     | TK_OP_DIFERENTE
+      {
+        $$ = "!=";
+      }
 ;
 
 expressao:
       expressao TK_OP_SOMA termo
+      {
+        /* Expressão binária de soma. Exemplo: a + b */
+        $$ = criar_no(NO_BINARIO, $1, $3, "+");
+      }
     | expressao TK_OP_SUBTRACAO termo
+      {
+        /* Expressão binária de subtração. Exemplo: a - b */
+        $$ = criar_no(NO_BINARIO, $1, $3, "-");
+      }
     | termo
+      {
+        $$ = $1;
+      }
 ;
 
 termo:
       termo TK_OP_MULTIPLICACAO fator
+      {
+        /* Expressão binária de multiplicação. Exemplo: a * b */
+        $$ = criar_no(NO_BINARIO, $1, $3, "*");
+      }
     | termo TK_OP_DIVISAO fator
+      {
+        /* Expressão binária de divisão. Exemplo: a / b */
+        $$ = criar_no(NO_BINARIO, $1, $3, "/");
+      }
     | termo TK_OP_MODULO fator
+      {
+        /* Expressão binária de módulo. Exemplo: a % b */
+        $$ = criar_no(NO_BINARIO, $1, $3, "%");
+      }
     | fator
+      {
+        $$ = $1;
+      }
 ;
 
 fator:
       NUMBER
+      {
+        /* Cria um nó para número. */
+        $$ = criar_no(NO_NUMERO, NULL, NULL, $1);
+        free($1);
+      }
     | IDENT
+      {
+        /* Cria um nó para identificador. */
+        $$ = criar_no(NO_IDENTIFICADOR, NULL, NULL, $1);
+        free($1);
+      }
     | acesso_vetor
+      {
+        $$ = $1;
+      }
     | TK_ABRE_PARENTESE expressao TK_FECHA_PARENTESE
+      {
+        $$ = $2;
+      }
 ;
 
 acesso_vetor:
       IDENT TK_ABRE_COLCHETE expressao TK_FECHA_COLCHETE
+      {
+        /*
+         * Acesso a vetor.
+         * Exemplo: vetor[i]
+         */
+        $$ = criar_no(NO_ACESSO_VETOR, $3, NULL, $1);
+        free($1);
+      }
 ;
 
 %%

--- a/teste.c
+++ b/teste.c
@@ -1,0 +1,11 @@
+int main() {
+    int x = 10;
+
+    if (x > 5) {
+        x = x - 1;
+    } else {
+        x = x + 1;
+    }
+
+    return x;
+}


### PR DESCRIPTION

# Descrição

Este PR integra o analisador sintático com a árvore sintática abstrata (AST), permitindo que o compilador deixe de apenas validar a sintaxe do código-fonte e passe também a construir uma representação estruturada do programa analisado.

A partir desta integração, o `parser.y` passa a criar nós da AST durante as reduções das regras gramaticais, enquanto o `scanner.l` passa a enviar valores léxicos para o parser por meio de `yylval`. Além disso, o `Makefile` foi atualizado para compilar o compilador completo utilizando Flex, Bison, AST e tabela de símbolos.

## Alterações realizadas

### Integração do parser com a AST

* Adicionada integração do `parser.y` com `ast.h`.
* Criado ponteiro global `raiz_ast` para armazenar a raiz da árvore sintática.
* Adicionado `%union` para permitir que o parser trabalhe com:

  * `char *` para valores léxicos de `IDENT` e `NUMBER`;
  * `NoAST *` para regras que produzem nós da AST.
* Adicionados `%type` para as principais regras gramaticais que retornam nós da árvore.

### Criação de nós da árvore sintática

Foram adicionadas ações semânticas para construção da AST em regras como:

* `programa`
* `lista_funcoes`
* `funcao`
* `parametros`
* `tipo`
* `bloco`
* `lista_comandos`
* `comando`
* `declaracao`
* `atribuicao`
* `incremento`
* `retorno`
* `comando_if`
* `comando_while`
* `comando_for`
* `expressao_booleana`
* `expressao`
* `termo`
* `fator`
* `acesso_vetor`

### Ajustes no scanner

* `IDENT` e `NUMBER` agora preenchem `yylval.str`.
* Adicionada função auxiliar para copiar o conteúdo de `yytext`.
* Adicionado controle de debug léxico com `DEBUG_LEXER`.
* Os prints do lexer foram encapsulados em `LEX_PRINT`, permitindo ativar ou desativar a impressão dos tokens conforme necessário.

### Ajustes na AST

* Definição dos tipos de nós usados pelo parser.
* Criação dinâmica de nós da AST.
* Cópia segura de strings usadas nos nós.
* Impressão recursiva da árvore sintática.
* Liberação recursiva da memória alocada pela AST.

### Atualização do Makefile

* O `Makefile` agora compila o compilador completo.
* Foram integrados ao processo de build:

  * `parser.y`
  * `scanner.l`
  * `ast.c`
  * `symtab.c`
* O alvo principal passou a gerar o executável:

```bash
build/compilador
```

